### PR TITLE
Remove cuda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: CI
+
+on: # this determines when this workflow is run
+  # push:
+  #    branches: [ main ] #  when branch is pushed to
+  pull_request:
+     branches: [ master ] # when there is a pull request against branch
+  workflow_dispatch: # allow manually starting this workflow
+
+jobs:
+  industrial_ci:
+    name: ROS ${{ matrix.ROS_DISTRO }} (${{ matrix.ROS_REPO }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix: # matrix is the product of entries
+        ROS_DISTRO: [humble]
+        ROS_REPO: [main]
+    env:
+      AFTER_INIT: "apt-get -qq install -y --no-upgrade --no-install-recommends libboost-all-dev libyaml-cpp-dev"
+    steps:
+      - name: checkout current repo
+        uses: actions/checkout@v3 # clone target repository
+        with:
+          path: "./hesai_ros_driver"
+      
+      - uses: 'ros-industrial/industrial_ci@master' # run industrial_ci
+        env: # either pass all entries explicitly
+          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          ROS_REPO: ${{ matrix.ROS_REPO }}
+        # with: # or pass the full matrix as config
+        #    config: ${{toJSON(matrix)}}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3 # clone target repository
         with:
           path: "./hesai_ros_driver"
+          submodules: "true"
       
       - uses: 'ros-industrial/industrial_ci@master' # run industrial_ci
         env: # either pass all entries explicitly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,37 +144,37 @@ add_subdirectory(src/driver/HesaiLidar_SDK_2.0)
 #                )
 
 
-find_package(CUDA)
-if(CUDA_FOUND)
-  
-  message(=============================================================)
-  message("-- CUDA Found. CUDA Support is turned On.")
-  message(=============================================================)
-
-  link_directories($ENV{CUDA_PATH}/lib/x64)
-  set(CUDA_NVCC_FLAGS "-arch=sm_75;-O2;-std=c++17")#根据具体GPU性能更改算力参数
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -rdc=true")
-  list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC)
-
-  CUDA_ADD_EXECUTABLE(hesai_ros_driver_node
-                node/hesai_ros_driver_node.cu
-                src/manager/node_manager.cu
-                ./src/driver/HesaiLidar_SDK_2.0/libhesai/UdpParserGpu/src/buffer.cu
-                )
-  set(CUDA_LIBS "${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so")
-
-  target_link_libraries(hesai_ros_driver_node                   
-                ${YAML_CPP_LIBRARIES}
-                ${Boost_LIBRARIES}
-                source_lib
-                container_lib
-                ptcClient_lib
-                ptcParser_lib
-                log_lib
-                ${CUDA_LIBS}
-                # libhesai
-    )
-else(CUDA_FOUND)
+# find_package(CUDA)
+# if(CUDA_FOUND)
+#   
+#   message(=============================================================)
+#   message("-- CUDA Found. CUDA Support is turned On.")
+#   message(=============================================================)
+# 
+#   link_directories($ENV{CUDA_PATH}/lib/x64)
+#   set(CUDA_NVCC_FLAGS "-arch=sm_75;-O2;-std=c++17")#根据具体GPU性能更改算力参数
+#   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -rdc=true")
+#   list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC)
+# 
+#   CUDA_ADD_EXECUTABLE(hesai_ros_driver_node
+#                 node/hesai_ros_driver_node.cu
+#                 src/manager/node_manager.cu
+#                 ./src/driver/HesaiLidar_SDK_2.0/libhesai/UdpParserGpu/src/buffer.cu
+#                 )
+#   set(CUDA_LIBS "${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so")
+# 
+#   target_link_libraries(hesai_ros_driver_node                   
+#                 ${YAML_CPP_LIBRARIES}
+#                 ${Boost_LIBRARIES}
+#                 source_lib
+#                 container_lib
+#                 ptcClient_lib
+#                 ptcParser_lib
+#                 log_lib
+#                 ${CUDA_LIBS}
+#                 # libhesai
+#     )
+# else(CUDA_FOUND)
 
   message(=============================================================)
   message("-- CUDA Not Found. CUDA Support is turned Off.")
@@ -194,7 +194,7 @@ else(CUDA_FOUND)
               # libhesai
   )            
 
-endif(CUDA_FOUND)
+# endif(CUDA_FOUND)
 
 
   target_include_directories(hesai_ros_driver_node PRIVATE


### PR DESCRIPTION
Remove cuda from CMakeList. @John-Henawy and I found that if CUDA is enabled (e.g. on the jetson) then the `ring` field is not populated in the scan. This causes undistortion to break.

Also add simple CI file to test building works.

